### PR TITLE
adding "expert" options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 Cargo.lock
 *.bk
 build.sh
+
+.DS_Store/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ readme = "README.md"
 keywords = ["tls", "ssl", "tcp", "crypto"]
 license = "MIT"
 
-version = "0.2.0"
-authors = ["Arturo Vergara <hello@arturovm.me>"]
+version = "0.2.1"
+authors = ["Arturo Vergara <hello@arturovm.me>", Joshua Steffensky "steffensky@fox4c.com"]
 
 [dependencies]
 openssl = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "FoxTLS"
+name = "foxtls"
 description = "A lightweight non-blocking TLS wrapper for the Rust standard library TCP listener."
 documentation = "https://fox4c.github.io/FoxTLS/"
 repository = "https://github.com/Fox4c/FoxTLS"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
-name = "caesar"
-description = "A drop-in replacement for the Rust standard library TCP listener with TLSv1.2 enabled."
-documentation = "https://arturovm.me/rustdoc/caesar/index.html"
-repository = "https://github.com/Postage/caesar"
+name = "FoxTLS"
+description = "A lightweight non-blocking TLS wrapper for the Rust standard library TCP listener."
+documentation = "https://fox4c.github.io/FoxTLS/"
+repository = "https://github.com/Fox4c/FoxTLS"
 readme = "README.md"
-keywords = ["tls", "ssl", "tcp", "crypto"]
+keywords = ["tls", "ssl", "tcp", "crypto", "mio", "non-blocking"]
 license = "MIT"
 
-version = "0.2.1"
-authors = ["Arturo Vergara <hello@arturovm.me>", "Joshua Steffensky <steffensky@fox4c.com>"]
+version = "0.0.1"
+authors = ["Joshua Steffensky <steffensky@fox4c.com>"]
 
 [dependencies]
-openssl = "0.7.6"
+openssl = "^0.7.6"
+mio = "^0.5.1"
 
 [features]
 default = ["tlsv1_2", "rfc5114"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["tls", "ssl", "tcp", "crypto"]
 license = "MIT"
 
 version = "0.2.1"
-authors = ["Arturo Vergara <hello@arturovm.me>", Joshua Steffensky "steffensky@fox4c.com"]
+authors = ["Arturo Vergara <hello@arturovm.me>", "Joshua Steffensky <steffensky@fox4c.com>"]
 
 [dependencies]
 openssl = "0.7.6"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Arturo Vergara <hello@arturovm.me>
+Copyright (c) 2015 Fox4c GbR <info@fox4c.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,49 +1,28 @@
-# Caesar
+# FoxTLS
 
-A drop-in replacement for the Rust standard library TCP listener with TLSv1.2 enabled.
+FoxTLS is a lightweight non-blocking TLS wrapper for the Rust standard library TCP listener.
+It is based on the [Postage/caesar](https://github.com/Postage/caesar).
 
-- [Documentation](https://arturovm.me/rustdoc/caesar/index.html)
-- [Crate](https://crates.io/crates/caesar)
+- [Documentation](https://fox4c.github.io/FoxTLS/)
+- [Crate](https://crates.io/crates/FoxTLS)
 
 _Note: This library hasn't been tested._
 
 ## Introduction
 
-This library abstracts over a regular TCP listener from the Rust standard library, and provides a drop-in* interface replacement that layers TLSv1.2 with a set of strong cipher suites on top of the connection.
+This library abstracts over a regular TCP listener from the Rust standard library, and provides a drop-in* interface replacement that layers TLS with a set of strong cipher suites on top of the connection.
 
-It uses the [OpenSSL library Rust bindings](https://github.com/sfackler/rust-openssl) by Steven Fackler for the underlying TLS functionality. If you don't trust OpenSSL (I don't), you can compile this crate against LibreSSL (instructions provided below).
+It uses the [OpenSSL library Rust bindings](https://github.com/sfackler/rust-openssl) by Steven Fackler for the underlying TLS functionality.
 
 _* It's only necessary to prepend `Tls` to the regular types (e.g. `TlsTcpListener`), and write error handling code for the new error types._
 
-## Compiling
 
-### Prerequisites
-
-- OpenSSL/LibreSSL headers
-
-How and where you install these headers depends on your platform. A quick Google search should do the trick.
-
-### Building
-
-As described in the [README](https://github.com/sfackler/rust-openssl) for the Rust OpenSSL bindings, there are various ways of compiling this crate, depending on your platform. However, the most universal route, is to configure your build manually with environment variables (and this is required anyway for compiling against LibreSSL). There are only three:
-
-- `OPENSSL_LIB_DIR`: Use this to specify the path to the _lib_ dir of your SSL library of choice
-- `OPENSSL_INCLUDE_DIR`: Use this to specify the path to the _include_ dir of your SSL library of choice
-- `OPENSSL_STATIC`: [optional] This is a boolean variable specifying whether to statically link against your SSL library
-
-The complete command might look something like this:
-
-```bash
-$ env OPENSSL_LIB_DIR="/usr/local/opt/libressl/lib" \
-        OPENSSL_INCLUDE_DIR="/usr/local/opt/libressl/include" \
-        OPENSSL_STATIC=true cargo build
-```
 ## Usage
 
-Caesar provides a `CaesarError` enum type, with a variant for I/O errors and another one for SSL errors. You can find the specifics in the library [docs](https://arturovm.me/rustdoc/caesar/index.html).
+FoxTLS provides a `FoxTLSError` enum type, with a variant for I/O errors and another one for SSL errors. You can find the specifics in the library [docs](https://fox4c.github.io/FoxTLS/FoxTLS/index.html).
 
 ```rust
-extern crate caesar;
+extern crate FoxTlS;
 
 use caesar::{TlsTcpListener, TlsTcpStream};
 use std::thread;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,11 @@
 //! drop(listener);
 //! ```
 
+extern crate mio;
 extern crate openssl;
 
 mod types;
 mod tcp;
 
-pub use types::{Result, CaesarError};
+pub use types::{Result, FoxTLSError};
 pub use tcp::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,46 +4,46 @@ use std::convert::From;
 use openssl::ssl::error::SslError;
 
 #[derive(Debug)]
-pub enum CaesarError {
+pub enum FoxTLSError {
     Ssl(SslError),
     Io(io::Error),
 }
 
-pub type Result<T> = result::Result<T, CaesarError>;
+pub type Result<T> = result::Result<T, FoxTLSError>;
 
-impl fmt::Display for CaesarError {
+impl fmt::Display for FoxTLSError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            CaesarError::Ssl(ref e) => write!(f, "SSL error: {}", e),
-            CaesarError::Io(ref e) => write!(f, "IO error: {}", e),
+            FoxTLSError::Ssl(ref e) => write!(f, "SSL error: {}", e),
+            FoxTLSError::Io(ref e) => write!(f, "IO error: {}", e),
         }
     }
 }
 
-impl error::Error for CaesarError {
+impl error::Error for FoxTLSError {
     fn description(&self) -> &str {
         match *self {
-            CaesarError::Ssl(ref e) => e.description(),
-            CaesarError::Io(ref e) => e.description(),
+            FoxTLSError::Ssl(ref e) => e.description(),
+            FoxTLSError::Io(ref e) => e.description(),
         }
     }
 
     fn cause(&self) -> Option<&error::Error> {
         match *self {
-            CaesarError::Ssl(ref e) => Some(e),
-            CaesarError::Io(ref e) => Some(e),
+            FoxTLSError::Ssl(ref e) => Some(e),
+            FoxTLSError::Io(ref e) => Some(e),
         }
     }
 }
 
-impl From<SslError> for CaesarError {
-    fn from(err: SslError) -> CaesarError {
-        CaesarError::Ssl(err)
+impl From<SslError> for FoxTLSError {
+    fn from(err: SslError) -> FoxTLSError {
+        FoxTLSError::Ssl(err)
     }
 }
 
-impl From<io::Error> for CaesarError {
-    fn from(err: io::Error) -> CaesarError {
-        CaesarError::Io(err)
+impl From<io::Error> for FoxTLSError {
+    fn from(err: io::Error) -> FoxTLSError {
+        FoxTLSError::Io(err)
     }
 }


### PR DESCRIPTION
Gives experienced developers to define which SslMethod, SslContextOptions, and which Ciphers should be used for TlsTcpListener.
